### PR TITLE
Add PA mode switch for Monoprice

### DIFF
--- a/homeassistant/components/monoprice/__init__.py
+++ b/homeassistant/components/monoprice/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import CONF_NOT_FIRST_RUN, DOMAIN, FIRST_RUN, MONOPRICE_OBJECT
 
-PLATFORMS = [Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.SWITCH]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/monoprice/strings.json
+++ b/homeassistant/components/monoprice/strings.json
@@ -1,50 +1,51 @@
 {
-  "config": {
-    "step": {
-      "user": {
-        "title": "Connect to the device",
-        "data": {
-          "port": "[%key:common::config_flow::data::port%]",
-          "source_1": "Name of source #1",
-          "source_2": "Name of source #2",
-          "source_3": "Name of source #3",
-          "source_4": "Name of source #4",
-          "source_5": "Name of source #5",
-          "source_6": "Name of source #6"
+    "config": {
+        "step": {
+            "user": {
+                "title": "Connect to the device",
+                "data": {
+                    "port": "[%key:common::config_flow::data::port%]",
+                    "source_1": "Name of source #1",
+                    "source_2": "Name of source #2",
+                    "source_3": "Name of source #3",
+                    "source_4": "Name of source #4",
+                    "source_5": "Name of source #5",
+                    "source_6": "Name of source #6",
+                },
+            }
+        },
+        "error": {
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "unknown": "[%key:common::config_flow::error::unknown%]",
+        },
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+        },
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Configure sources",
+                "data": {
+                    "source_1": "[%key:component::monoprice::config::step::user::data::source_1%]",
+                    "source_2": "[%key:component::monoprice::config::step::user::data::source_2%]",
+                    "source_3": "[%key:component::monoprice::config::step::user::data::source_3%]",
+                    "source_4": "[%key:component::monoprice::config::step::user::data::source_4%]",
+                    "source_5": "[%key:component::monoprice::config::step::user::data::source_5%]",
+                    "source_6": "[%key:component::monoprice::config::step::user::data::source_6%]",
+                },
+            }
         }
-      }
     },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+    "services": {
+        "snapshot": {
+            "name": "Snapshot",
+            "description": "Takes a snapshot of the media player zone.",
+        },
+        "restore": {
+            "name": "Restore",
+            "description": "Restores a snapshot of the media player zone.",
+        },
     },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Configure sources",
-        "data": {
-          "source_1": "[%key:component::monoprice::config::step::user::data::source_1%]",
-          "source_2": "[%key:component::monoprice::config::step::user::data::source_2%]",
-          "source_3": "[%key:component::monoprice::config::step::user::data::source_3%]",
-          "source_4": "[%key:component::monoprice::config::step::user::data::source_4%]",
-          "source_5": "[%key:component::monoprice::config::step::user::data::source_5%]",
-          "source_6": "[%key:component::monoprice::config::step::user::data::source_6%]"
-        }
-      }
-    }
-  },
-  "services": {
-    "snapshot": {
-      "name": "Snapshot",
-      "description": "Takes a snapshot of the media player zone."
-    },
-    "restore": {
-      "name": "Restore",
-      "description": "Restores a snapshot of the media player zone."
-    }
-  }
+    "entity": {"switch": {"pa_mode": {"name": "PA mode"}}},
 }

--- a/homeassistant/components/monoprice/switch.py
+++ b/homeassistant/components/monoprice/switch.py
@@ -1,0 +1,74 @@
+"""Switches for the Monoprice 6-Zone Amplifier."""
+
+from __future__ import annotations
+
+import logging
+
+from serial import SerialException
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN, MONOPRICE_OBJECT
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Monoprice PA switch."""
+    monoprice = hass.data[DOMAIN][entry.entry_id][MONOPRICE_OBJECT]
+    async_add_entities([MonopricePASwitch(monoprice, entry.entry_id)])
+
+
+class MonopricePASwitch(SwitchEntity):
+    """Representation of the PA mode switch."""
+
+    _attr_has_entity_name = True
+    _attr_name = "PA Mode"
+
+    def __init__(self, monoprice, entry_id: str) -> None:
+        """Initialize the switch."""
+        self._monoprice = monoprice
+        self._attr_unique_id = f"{entry_id}_pa_mode"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry_id)},
+            manufacturer="Monoprice",
+            model="6-Zone Amplifier",
+            name="Monoprice 6-Zone Amplifier",
+        )
+        self._is_on = False
+
+    @property
+    def is_on(self) -> bool:
+        """Return if PA mode is enabled."""
+        return self._is_on
+
+    def turn_on(self, **kwargs) -> None:
+        """Enable PA mode."""
+        try:
+            self._monoprice.set_pa(True)
+            self._is_on = True
+        except SerialException:
+            _LOGGER.warning("Failed to enable PA mode")
+
+    def turn_off(self, **kwargs) -> None:
+        """Disable PA mode."""
+        try:
+            self._monoprice.set_pa(False)
+            self._is_on = False
+        except SerialException:
+            _LOGGER.warning("Failed to disable PA mode")
+
+    def update(self) -> None:
+        """Fetch current state."""
+        try:
+            self._is_on = bool(self._monoprice.get_pa())
+        except SerialException:
+            _LOGGER.warning("Failed to update PA mode state")

--- a/tests/components/monoprice/test_switch.py
+++ b/tests/components/monoprice/test_switch.py
@@ -1,0 +1,77 @@
+"""Test Monoprice switches."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.monoprice.const import CONF_PORT, CONF_SOURCES, DOMAIN
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+MOCK_CONFIG = {CONF_PORT: "fake port", CONF_SOURCES: {}}
+
+
+class MockMonoprice:
+    """Mock for pymonoprice object for switch tests."""
+
+    def __init__(self) -> None:
+        """Initialize the mock."""
+        self.pa = False
+
+    def set_pa(self, enabled: bool) -> None:
+        """Set the PA mode state."""
+        self.pa = enabled
+
+    def get_pa(self) -> bool:
+        """Return the current PA mode state."""
+        return self.pa
+
+
+@pytest.mark.parametrize("load_platforms", [[Platform.SWITCH]])
+async def test_pa_switch(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the PA mode switch."""
+    monoprice = MockMonoprice()
+
+    with patch(
+        "homeassistant.components.monoprice.get_monoprice",
+        new=lambda *a: monoprice,
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+    with patch.object(monoprice, "set_pa") as mock_set_pa:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.pa_mode"},
+            blocking=True,
+        )
+        mock_set_pa.assert_called_once_with(True)
+
+    with patch.object(monoprice, "set_pa") as mock_set_pa:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.pa_mode"},
+            blocking=True,
+        )
+        mock_set_pa.assert_called_once_with(False)


### PR DESCRIPTION
## Summary
- expose public address mode as a switch for the Monoprice 6‑Zone Amplifier
- document new switch entity translation
- test PA mode switch functionality

## Testing
- `pre-commit run --files homeassistant/components/monoprice/__init__.py homeassistant/components/monoprice/switch.py homeassistant/components/monoprice/strings.json tests/components/monoprice/test_switch.py` *(fails: command not found)*
- `pytest tests/components/monoprice/test_switch.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68818809bd94832f9dc7db7d977607e1